### PR TITLE
FG-398 Extension properties for manual configuration

### DIFF
--- a/src/Orc.FileAssociation.Example/ViewModels/MainViewModel.cs
+++ b/src/Orc.FileAssociation.Example/ViewModels/MainViewModel.cs
@@ -13,6 +13,7 @@ namespace Orc.FileAssociation.ViewModels
     using Catel.Data;
     using Catel.MVVM;
     using Catel.Reflection;
+    using Orc.FileAssociation.Win32;
 
     public class MainViewModel : ViewModelBase
     {
@@ -36,6 +37,7 @@ namespace Orc.FileAssociation.ViewModels
             UnregisterApplication = new Command(OnUnregisterApplicationExecute, OnUnregisterApplicationCanExecute);
             AssociateFiles = new TaskCommand(OnAssociateFilesExecuteAsync, OnAssociateFilesCanExecute);
             UndoAssociationFiles = new TaskCommand(OnUndoAssociateFilesExecuteAsync, OnAssociateFilesCanExecute);
+            OpenExtensionProperties = new TaskCommand(OnOpenExtensionPropertiesAsync);
             Title = "Orc.FileAssociation example";
         }
 
@@ -104,13 +106,23 @@ namespace Orc.FileAssociation.ViewModels
         {
             await _fileAssociationService.UndoAssociationFilesWithApplicationAsync(ApplicationInfo);
         }
+
+        public TaskCommand OpenExtensionProperties { get; private set; }
+
+        private async Task OnOpenExtensionPropertiesAsync()
+        {
+            foreach (var extension in FileAssociations.Split(new string[] { ",", ";" }, StringSplitOptions.RemoveEmptyEntries))
+            {
+                await _fileAssociationService.OpenPropertiesWindowForExtensionAsync(extension);
+            }
+        }
+
         #endregion
 
         #region Methods
         protected override async Task InitializeAsync()
         {
             await base.InitializeAsync();
-
             UpdateState();
         }
 

--- a/src/Orc.FileAssociation.Example/Views/MainWindow.xaml
+++ b/src/Orc.FileAssociation.Example/Views/MainWindow.xaml
@@ -26,6 +26,7 @@
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
 
                 <Grid.ColumnDefinitions>
@@ -50,6 +51,7 @@
                 <Button Grid.ColumnSpan="2" Content="Unregister application" Command="{Binding UnregisterApplication}" />
                 <Button Grid.ColumnSpan="2" Content="Associate extensions" Command="{Binding AssociateFiles}" />
                 <Button Grid.ColumnSpan="2" Content="Undo extensions associations" Command="{Binding UndoAssociationFiles}" />
+                <Button Grid.ColumnSpan="2" Content="Set extension handler via properties window" Command="{Binding OpenExtensionProperties}" />
 
             </orccontrols:StackGrid>
         </GroupBox>

--- a/src/Orc.FileAssociation/Services/FileAssociationService.cs
+++ b/src/Orc.FileAssociation/Services/FileAssociationService.cs
@@ -8,11 +8,13 @@
 namespace Orc.FileAssociation
 {
     using System;
+    using System.IO;
     using System.Runtime.InteropServices;
     using System.Threading.Tasks;
     using Catel;
     using Catel.Logging;
     using Microsoft.Win32;
+    using Orc.FileAssociation.Win32;
 
     public class FileAssociationService : IFileAssociationService
     {
@@ -101,6 +103,16 @@ namespace Orc.FileAssociation
                 Log.Debug($"Removed extension association for {finalExtension} from current user");
             }
 
+        }
+
+        public async Task OpenPropertiesWindowForExtensionAsync(string extension)
+        {
+            var appPath = AppDomain.CurrentDomain.BaseDirectory;
+            var fileName = $"Click on 'Change' to select default {extension} handler.{extension}";
+            var finalPath = Path.Combine(appPath, fileName);
+
+            File.Create(finalPath).Dispose();
+            Shell32.ShowFileProperties(finalPath);
         }
     }
 }

--- a/src/Orc.FileAssociation/Services/Interfaces/IFileAssociationService.cs
+++ b/src/Orc.FileAssociation/Services/Interfaces/IFileAssociationService.cs
@@ -20,5 +20,7 @@ namespace Orc.FileAssociation
         Task AssociateFilesWithApplicationAsync(ApplicationInfo applicationInfo);
 
         Task UndoAssociationFilesWithApplicationAsync(ApplicationInfo applicationInfo);
+
+        Task OpenPropertiesWindowForExtensionAsync(string extension);
     }
 }

--- a/src/Orc.FileAssociation/Win32/Shell32.cs
+++ b/src/Orc.FileAssociation/Win32/Shell32.cs
@@ -1,0 +1,50 @@
+﻿namespace Orc.FileAssociation.Win32
+{
+    using System;
+    using System.Runtime.InteropServices;
+
+    //Credits:
+    //https://pinvoke.net/default.aspx/shell32/ShellExecuteEx.html
+
+    public static class Shell32
+    {
+        [DllImport("shell32.dll", CharSet = CharSet.Auto)]
+        internal static extern bool ShellExecuteEx(ref SHELLEXECUTEINFO lpExecInfo);
+
+        public static void ShowFileProperties(string fileName)
+        {
+            SHELLEXECUTEINFO info = new SHELLEXECUTEINFO();
+            info.cbSize = Marshal.SizeOf(info);
+            info.lpVerb = "properties";
+            info.lpFile = fileName;
+            info.nShow = 5;
+            info.fMask = 12;
+            ShellExecuteEx(ref info);
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct SHELLEXECUTEINFO
+        {
+            public int cbSize;
+            public uint fMask;
+            public IntPtr hwnd;
+            [MarshalAs(UnmanagedType.LPTStr)]
+            public string lpVerb;
+            [MarshalAs(UnmanagedType.LPTStr)]
+            public string lpFile;
+            [MarshalAs(UnmanagedType.LPTStr)]
+            public string lpParameters;
+            [MarshalAs(UnmanagedType.LPTStr)]
+            public string lpDirectory;
+            public int nShow;
+            public IntPtr hInstApp;
+            public IntPtr lpIDList;
+            [MarshalAs(UnmanagedType.LPTStr)]
+            public string lpClass;
+            public IntPtr hkeyClass;
+            public uint dwHotKey;
+            public IntPtr hIcon;
+            public IntPtr hProcess;
+        }
+    }
+}


### PR DESCRIPTION
### Description of Change ###

After Windows 10 Threshold 2 update, Microsoft does not allow you to associate with an extension programmatically if there is already an association with another program.
I saw similar solution in a product from Adobe. They open the properties of the file with the desired extension and show a picture with instructions.
So I made appropriate changes in Orc.FileAssociation and created a wizard in Gum.UI similar to what I saw 

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #

### API Changes ###
<!-- List all API changes here (or just put None) -->
 
None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- All
- WPF
- UWP
- iOS
- Android

### Behavioral Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
